### PR TITLE
build: separate browser builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,17 @@ jobs:
       - run: corepack enable
       - run: yarn install
       - run: yarn run prod
-      - run: zip -r dist/browser/browser.zip dist/browser/*
+      - name: Package for Chrome
+        working-directory: dist/browser/chrome
+        run: zip -r ../garmin-connect-enhancements.unpackaged.chrome.zip *
+      - name: Package for Firefox / Gecko
+        working-directory: dist/browser/gecko
+        run: zip -r ../garmin-connect-enhancements.unpackaged.gecko.zip *
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |
-            dist/browser/browser.zip
+            dist/browser/garmin-connect-enhancements.unpackaged.chrome.zip
+            dist/browser/garmin-connect-enhancements.unpackaged.gecko.zip
             dist/userscript/garmin-connect-enhancements.user.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,6 @@ jobs:
           token: ${{ secrets.PAT }}
           fail_on_unmatched_files: true
           files: |
-            dist/browser/browser.zip
+            dist/browser/garmin-connect-enhancements.unpackaged.chrome.zip
+            dist/browser/garmin-connect-enhancements.unpackaged.gecko.zip
             dist/userscript/garmin-connect-enhancements.user.js

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -24,7 +24,9 @@ Run `yarn run build:prod`
 ## Build and distributable directories breakdown
 * `build/` _(contains the raw build files)_
 * `dist/`
-  * `browser/` _(contains the browser extension distributables)_
+  * `browser/`
+    * `chrome/` _(contains the Chrome extension files)_
+    * `gecko/` _(contains the Firefox add-on files)_
   * `userscript/` _(contains the UserScript distributable)_
 
 ## Build & Watch For Changes

--- a/templates/browser/manifest.json
+++ b/templates/browser/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Enhancements for Garmin Connect",
-  "version": [VERSION],
-  "description": [DESCRIPTION],
+  "version": "",
+  "description": "",
   "icons": {
     "16": "logo-16.png",
     "32": "logo-32.png",
@@ -14,13 +14,19 @@
       "js": [
         "content-script.js"
       ],
-      "matches": ["*://connect.garmin.com/*"]
+      "matches": [
+        "*://connect.garmin.com/*"
+      ]
     }
   ],
   "web_accessible_resources": [
     {
-      "resources": ["app.js"],
-      "matches": ["*://connect.garmin.com/*"]
+      "resources": [
+        "app.js"
+      ],
+      "matches": [
+        "*://connect.garmin.com/*"
+      ]
     }
   ],
   "browser_specific_settings": {


### PR DESCRIPTION
## Description

Fixes the incompatible unpacked extension files built from CI. The previous `manifest.json` added properties that Chrome does not support of which Gecko requires. Browser builds are separated into two categories, `chrome` and `gecko`.

## PR Type
- [ ] Bug fix
- [ ] Feature
- [ ] Code-style update
- [ ] Refactoring
- [ ] Documentation update
- [x] Build related changes
- [x] CI / CD related changes
- [ ] Other, describe here: 

## Tests performed

On Github, using Github Actions.

## Screenshots

<!--- Add screenshots here, if appropriate -->

## Additional information

<!--- Add additional information here, if appropriate -->